### PR TITLE
Let module run in check mode

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -6,6 +6,7 @@
     shell: "uname -m"
     register: arch_result
     changed_when: false
+    check_mode: no
   - set_fact:
       arch: arch_result.stdout
   - name: translate amd architecture

--- a/tasks/verify.yml
+++ b/tasks/verify.yml
@@ -15,7 +15,7 @@
 - name: fail if the the fingerprint can't be verified
   fail:
     msg: "the gpg key does not match the fingerprint"
-  when: public_key_fingerprint not in fingerprint_result.stdout
+  when: fingerprint_result.stdout is defined and public_key_fingerprint not in fingerprint_result.stdout
 
 # NOTE: command returns result on stderr. not sure why
 - name: import the gpg key


### PR DESCRIPTION
A couple modifications so that the module can be run in check mode. Otherwise it fails when running ansible with `--check`. Shouldn't have any effect when not running in check mode.