### PR TITLE
Workaround for cloudwatch agent moving the config file, causing a change on every execution of a playbook.

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -18,3 +18,12 @@
     dest: "/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json"
     mode: "u=rw,g=r,o=r"
   notify: restart cloudwatch agent
+
+- name: force handlers to run before retemplating the config
+  meta: flush_handlers
+
+- name: retemplate the cloudwatch configuration
+  template:
+    src: "{{ config_template }}"
+    dest: "/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json"
+    mode: "u=rw,g=r,o=r"


### PR DESCRIPTION
Cause the cloudwatch agent service to restart after templating, then template the config file again. This will leave a copy of the config in the original place so that future executions of the role do not cause a `change` to occur.